### PR TITLE
Update gh workflow to use v4 of actions/cache

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           node-version: '18'
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.npm


### PR DESCRIPTION
As per action [documentation](https://github.com/actions/cache?tab=readme-ov-file#whats-new), v2 is now deprecated.