### PR TITLE
Use python3 instead of python in Makefile for macOS compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .DEFAULT_GOAL := build
 
 jobs:
-	python tools/bundle_posts.py
+	python3 tools/bundle_posts.py
 
 develop: jobs
 	gatsby develop


### PR DESCRIPTION
macOS does not provide a `python` binary by default, which causes `make develop`
to fail when running `tools/bundle_posts.py`.

This change updates the Makefile to explicitly use `python3`, improving
contributor onboarding without changing behavior.
